### PR TITLE
Fix PHP warning in translator

### DIFF
--- a/src/esas/cmsgate/lang/TranslatorImpl.php
+++ b/src/esas/cmsgate/lang/TranslatorImpl.php
@@ -12,7 +12,7 @@ use esas\cmsgate\Registry;
  */
 class TranslatorImpl extends Translator
 {
-    private $lang;
+    private $lang = [];
 
     /**
      * @var LocaleLoaderCms
@@ -39,7 +39,7 @@ class TranslatorImpl extends Translator
 
     private function loadLocale($locale)
     {
-        if (!isset($this->lang) || null == $this->lang[$locale]) {
+        if (!isset($this->lang[$locale])) {
             $this->loadLocaleFromDir(__DIR__, $locale); //загружаем локаль из каталога lang core
             foreach ($this->extraVocabularyDirs as $extraVocabularyDir) {
                 $this->loadLocaleFromDir($extraVocabularyDir, $locale); //загружаем локаль для каталога lang наследника
@@ -60,7 +60,7 @@ class TranslatorImpl extends Translator
             return;
         }
         $vocabulary = include $file;
-        if (isset($this->lang) && is_array($this->lang[$locale]))
+        if (isset($this->lang[$locale]))
             $this->lang[$locale] = array_merge($this->lang[$locale], $vocabulary);
         else
             $this->lang[$locale] = $vocabulary;


### PR DESCRIPTION
Lib ver. 1.13.x

```
Warning: Trying to access array offset on value of type null in /vendor/esas/cmsgate-core/src/esas/cmsgate/lang/TranslatorImpl.php on line 63


18 | 1.2331 | 12604232 | esas\cmsgate\epos\view\client\CompletionPanelEpos->render( ) | .../hutkigroshepos_end.php:13
19 | 1.2361 | 12672488 | esas\cmsgate\epos\view\client\CompletionPanelEpos->addTabs( ) | .../CompletionPanelEpos.php:86
20 | 1.2361 | 12672488 | esas\cmsgate\epos\view\client\CompletionPanelEpos->elementInstructionsTab( ) | .../CompletionPanelEpos.php:122
21 | 1.2361 | 12672488 | esas\cmsgate\epos\view\client\CompletionPanelEpos->getInstructionsTabLabel( ) | .../CompletionPanelEpos.php:402
22 | 1.2369 | 12672872 | esas\cmsgate\lang\TranslatorImpl->translate( $msg = 'epos_instructions_tab_label', $locale = ??? ) | .../CompletionPanelEpos.php:142
23 | 1.2369 | 12672904 | esas\cmsgate\lang\TranslatorImpl->loadLocale( $locale = 'ru_RU' ) | .../TranslatorImpl.php:77
24 | 1.2369 | 12672904 | esas\cmsgate\lang\TranslatorImpl->loadLocaleFromDir( $dir = '/............/vendor/esas/cmsgate-core/src/esas/cmsgate/lang', $locale = 'ru_RU' )

```